### PR TITLE
CustomAuthenticationProvider 적용 및 세션 보안 강화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.5'
 	id 'io.spring.dependency-management' version '1.1.7'
+	// 테스트 커버리지 리포트용 JaCoCo 플러그인
+	id 'jacoco'
 }
 
 group = 'com.manwon.happiness'
@@ -44,4 +46,17 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	// 테스트 끝나고 커버리지 리포트도 자동 생성
+	finalizedBy 'jacocoTestReport'
+}
+
+// JaCoCo 리포트 설정
+jacocoTestReport {
+	dependsOn test // test 실행 후 리포트 생성
+	reports {
+		xml.required = true    // CI/CD에서 활용 가능 (원하면 꺼도 됨)
+		csv.required = false
+		html.required = true   // 로컬에서 확인할 때 주로 씀
+		html.outputLocation = layout.buildDirectory.dir("jacocoHtml")
+	}
 }

--- a/src/main/java/com/manwon/happiness/auth/model/CustomUserDetails.java
+++ b/src/main/java/com/manwon/happiness/auth/model/CustomUserDetails.java
@@ -9,30 +9,36 @@ import java.util.List;
 
 public class CustomUserDetails implements UserDetails {
 
-    private final Member member;
+    private final Long memberId;
+    private final String email;
+    private final String nickname;
+    private final String role;
 
     public CustomUserDetails(Member member) {
-        this.member = member;
-    }
-
-    public Member getMember() {
-        return member;
+        this.memberId = member.getMemberId();
+        this.email = member.getEmail();
+        this.nickname = member.getNickname();
+        this.role = member.getRole().name();
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         // 단일 Role을 GrantedAuthority로 변환
-        return List.of((GrantedAuthority) () -> "ROLE_" + member.getRole().name());
+        return List.of((GrantedAuthority) () -> "ROLE_" + role);
     }
 
     @Override
     public String getUsername() {
-        return member.getEmail();
+        return email;
     }
 
     @Override
     public String getPassword() {
-        return member.getPasswordHash();
+        return null; // 세션에 비밀번호 저장 안함
+    }
+
+    public String getNickname() {
+        return nickname;
     }
 
     @Override

--- a/src/main/java/com/manwon/happiness/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/manwon/happiness/auth/service/CustomUserDetailsService.java
@@ -3,7 +3,6 @@ package com.manwon.happiness.auth.service;
 import com.manwon.happiness.auth.model.CustomUserDetails;
 import com.manwon.happiness.member.entity.Member;
 import com.manwon.happiness.member.repository.MemberRepository;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;

--- a/src/main/java/com/manwon/happiness/global/config/CustomAuthenticationProvider.java
+++ b/src/main/java/com/manwon/happiness/global/config/CustomAuthenticationProvider.java
@@ -1,0 +1,51 @@
+package com.manwon.happiness.global.config;
+
+import com.manwon.happiness.auth.model.CustomUserDetails;
+import com.manwon.happiness.member.entity.Member;
+import com.manwon.happiness.member.repository.MemberRepository;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public CustomAuthenticationProvider(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
+        this.memberRepository = memberRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String email = authentication.getName();
+        String rawPassword = (String) authentication.getCredentials();
+
+        // 1. 이메일로 사용자 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 회원입니다."));
+
+        // 2. 비밀번호 검증
+        if (!passwordEncoder.matches(rawPassword, member.getPasswordHash())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 3. 비밀번호 제외한 UserDetails 생성
+        CustomUserDetails userDetails = new CustomUserDetails(member);
+
+        // 4. 인증 성공 시 Authentication 반환
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/test/java/com/manwon/happiness/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/manwon/happiness/auth/controller/AuthControllerIntegrationTest.java
@@ -13,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.test.web.servlet.MockMvc;
@@ -20,7 +22,6 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDateTime;
 
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -56,25 +57,78 @@ class AuthControllerIntegrationTest {
         memberRepository.save(member);
     }
 
-    @DisplayName("로그인 성공 시 세션 발급")
-    @Test
-    void 로그인_성공() throws Exception {
-        // given
-        LoginRequestDto requestDto = new LoginRequestDto("test@test.com", "password123");
+//    @DisplayName("로그인 성공 시 세션 발급")
+//    @Test
+//    void 로그인_성공() throws Exception {
+//        // given
+//        LoginRequestDto requestDto = new LoginRequestDto("test@test.com", "password123");
+//
+//        // when & then
+//        mockMvc.perform(post("/api/v1/auth/login")
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .content(objectMapper.writeValueAsString(requestDto)))
+//                .andExpect(status().isOk())
+//                // 세션에 SecurityContext가 들어갔는지 확인
+//                .andExpect(request().sessionAttribute(
+//                        HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
+//                        notNullValue()
+//                ))
+//                .andExpect(jsonPath("$.nickname").value("tester"))
+//                .andExpect(jsonPath("$.role").value("MEMBER"));
+//    }
+@DisplayName("로그인 성공 시 세션 + SecurityContext 저장/인증 정보 확인")
+@Test
+void 로그인_성공() throws Exception {
+    // given
+    LoginRequestDto requestDto = new LoginRequestDto("test@test.com", "password123");
 
-        // when & then
-        mockMvc.perform(post("/api/v1/auth/login")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isOk())
-                // 세션에 SecurityContext가 들어갔는지 확인
-                .andExpect(request().sessionAttribute(
-                        HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY,
-                        notNullValue()
-                ))
-                .andExpect(jsonPath("$.nickname").value("tester"))
-                .andExpect(jsonPath("$.role").value("MEMBER"));
-    }
+    // when
+    MvcResult result = mockMvc.perform(post("/api/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            // 응답 바디 확인
+            .andExpect(jsonPath("$.nickname").value("tester"))
+            .andExpect(jsonPath("$.role").value("MEMBER"))
+            .andReturn();
+
+    // then — 세션/시큐리티 컨텍스트/인증 객체 검증
+    MockHttpSession session = (MockHttpSession) result.getRequest().getSession(false);
+    assertNotNull(session, "세션이 생성되어야 합니다.");
+
+    Object ctxAttr = session.getAttribute(
+            HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY
+    );
+    assertNotNull(ctxAttr, "SecurityContext가 세션에 저장되어야 합니다.");
+
+    SecurityContext context = (SecurityContext) ctxAttr;
+    Authentication auth = context.getAuthentication();
+    assertNotNull(auth, "Authentication이 존재해야 합니다.");
+    assertTrue(auth.isAuthenticated(), "인증 상태여야 합니다.");
+
+    // 인증 성공 후 credentials는 null이어야 함
+    assertNull(auth.getCredentials(), "인증 성공 후 credentials는 null이어야 합니다.");
+
+    // 사용자명(email) 확인
+    assertEquals("test@test.com", auth.getName());
+
+    // principal 타입/값 확인
+    Object principal = auth.getPrincipal();
+    assertTrue(principal instanceof com.manwon.happiness.auth.model.CustomUserDetails);
+    com.manwon.happiness.auth.model.CustomUserDetails user =
+            (com.manwon.happiness.auth.model.CustomUserDetails) principal;
+
+    assertEquals("tester", user.getNickname());
+
+    // 권한 확인 (ROLE_MEMBER)
+    assertTrue(
+            auth.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_MEMBER")),
+            "ROLE_MEMBER 권한이어야 합니다."
+    );
+
+    // (선택) 세션 타임아웃 검증 — AuthService에서 MEMBER 30분으로 설정
+    assertEquals(30 * 60, session.getMaxInactiveInterval(), "세션 타임아웃(초) 불일치");
+}
 
     @DisplayName("로그인 실패 - 잘못된 비밀번호")
     @Test

--- a/src/test/java/com/manwon/happiness/global/config/CustomAuthenticationProviderUnitTest.java
+++ b/src/test/java/com/manwon/happiness/global/config/CustomAuthenticationProviderUnitTest.java
@@ -1,0 +1,71 @@
+package com.manwon.happiness.global.config;
+
+import com.manwon.happiness.member.entity.Member;
+import com.manwon.happiness.member.entity.Role;
+import com.manwon.happiness.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CustomAuthenticationProviderUnitTest {
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAll();
+        Member member = Member.builder()
+                .email("unit@test.com")
+                .passwordHash(passwordEncoder.encode("password123"))
+                .nickname("unitTester")
+                .role(Role.MEMBER)
+                .build();
+        memberRepository.save(member);
+    }
+
+    @DisplayName("커스텀 AuthenticationProvider - 로그인 성공")
+    @Test
+    void 로그인성공() {
+        // given
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("unit@test.com", "password123");
+
+        // when
+        Authentication authentication = authenticationManager.authenticate(token);
+
+        // then
+        assertNotNull(authentication);
+        assertTrue(authentication.isAuthenticated());
+        assertEquals("unit@test.com", authentication.getName());
+    }
+
+    @DisplayName("커스텀 AuthenticationProvider - 로그인 실패 (비밀번호 불일치)")
+    @Test
+    void 로그인실패() {
+        // given
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken("unit@test.com", "wrongPassword");
+
+        // when & then
+        assertThrows(BadCredentialsException.class, () ->
+                authenticationManager.authenticate(token)
+        );
+    }
+}


### PR DESCRIPTION
개요
• Spring Security 기본 DaoAuthenticationProvider 대신 CustomAuthenticationProvider 를 도입
• 세션 직렬화 시 불필요하게 노출될 수 있는 passwordHash 제거
• 통합 테스트 강화: AuthControllerIntegrationTest 에서 세션, SecurityContext, Authentication 검증 추가

주요 변경 사항
1. 인증 로직
• CustomAuthenticationProvider 구현 및 SecurityConfig에 적용
• CustomUserDetails 수정 → passwordHash 제거 (세션 직렬화 시 보안 강화)

2. 테스트 코드
• AuthControllerIntegrationTest
• 로그인 성공 시 세션, SecurityContext, Authentication 검증
• 인증 성공 후 credentials 가 null 인지 확인
• 세션 타임아웃(30분) 확인
• 로그인 실패(비밀번호 오류, 존재하지 않는 이메일), 로그아웃 성공 시나리오 추가

3. 빌드/커버리지
• JaCoCo 테스트 커버리지 리포트 확인